### PR TITLE
Removing the TF_API_TOKEN

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,8 +69,6 @@ jobs:
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
-      with:
-        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     #- name: Terraform Init


### PR DESCRIPTION
The GitHub Actions for this repository should not use Terraform Cloud.  There's no need to have remote state handling since it's an apply, verify, and destroy.