### PR TITLE
Changing target_size for bastion IGM from 0 to 1

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -29,7 +29,7 @@ resource "google_compute_region_instance_group_manager" "bastion" {
     port = 22
   }
 
-  target_size = 0
+  target_size = 1
 
   auto_healing_policies {
     health_check      = google_compute_health_check.bastion.id


### PR DESCRIPTION
This change addresses #12 

As a result of this change, bastion IGM will now start with a target size of 1.  In the verification script, there is a command that resizes the IGM to `1`.  It has been left in place for now, since even if the IGM target size is already 1, the command succeeds.  At some point, if it's found to be useless (there are no reasonable scenarios where the size had been changed to 0), it could be removed.