### PR TITLE
Only Run Validation Workflow on Pull Requests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,9 +1,6 @@
 name: 'Validate'
 
 on:
-  push:
-    branches:
-    - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This change removes pushes to the *main* branch as a trigger for the validation workflow in GitHub actions.  Given that the validation workflow runs in the Pull Request and the *main* branch protection rules requires the Pull Request to be up to date with the *main* branch, the second execution is unnecessary.

This change addresses Issue #14 